### PR TITLE
docs: update the standards track categories

### DIFF
--- a/AIP-template.md
+++ b/AIP-template.md
@@ -5,8 +5,8 @@
   Status: *Draft, Rejected or Active*
   Discussions-To: https://github.com/arkecosystem/AIPS/issues
   Address: *Ark address used to collect votes for the specific AIP*
-  Type: *Standards (Core, Networking, Interface, Consensus)/Process/Informational*
-  Category *only required for Standards Track: <Core | Networking | Interface | Consensus>
+  Type: *Standards (Applications, Consensus, Core, Network, Protocol)/Process/Informational*
+  Category *only required for Standards Track: <Applications | Consensus | Core | Network | Protocol>
   Created: *YYYY-MM-DD*
   Last Update: *YYYY-MM-DD*
   Requires (*optional): <AIP number(s)>

--- a/AIPS/aip-1.md
+++ b/AIPS/aip-1.md
@@ -21,7 +21,7 @@ Because the AIPs are maintained as text files in a GitHub repository, their revi
 
 There are three kinds of AIP:
 
-* Standards Track AIP describes any change that affects mostly Ark core implementations, such as a change to the network protocol, a change in block or transaction validity rules, or any change or addition that affects the interoperability of applications. Standard track also defines category (Core, Networking, Interface, Consensus).
+* Standards Track AIP describes any change that affects mostly Ark core implementations, such as a change to the network protocol, a change in block or transaction validity rules, or any change or addition that affects the interoperability of applications. Standard track also defines category (Applications, Consensus, Core, Network, Protocol).
 
 * Informational AIP describes Ark's design issue, or provides general guidelines or information to the community, but does not propose a new feature. Informational AIPs do not necessarily represent a community consensus or recommendation, so users and implementors are free to ignore Informational AIPs or follow their advice.
 


### PR DESCRIPTION
Apart from sorting the standard track categories:
 - The categories "Applications" and "Protocol" have been used several times; I've added them.
 - The category "Networking" has been used as "Network" so I've updated it.
 - The category "Interface" hasn't been used and it's not clear: interface between what?