### PR TITLE
docs: correct word

### DIFF
--- a/AIPS/aip-102.md
+++ b/AIPS/aip-102.md
@@ -86,7 +86,7 @@ HTLC transactions are a safe and cheap method of exchanging secrets for money ov
 
 **AIP-29, AIP-11, AIP-18.** 
 
-> This specification super-seeds the basic timelock specification in AIP-11.
+> This specification supersedes the basic timelock specification in AIP-11.
 
 ## General Features
 


### PR DESCRIPTION
correct word super-seeds to supersedes