### PR TITLE
AIP37: Switch Delegate With Single Vote Transaction

### DIFF
--- a/AIPS/aip-37.md
+++ b/AIPS/aip-37.md
@@ -1,6 +1,6 @@
 ```
   AIP: 37
-  Title: Multivote Transaction
+  Title: Switch Delegate With Single Vote Transaction
   Authors: Dmitry Tyshchenko <dmitry@ark.io>
   Status: Draft
   Discussions-To: https://github.com/arkecosystem/AIPS/issues
@@ -12,7 +12,7 @@
 
 ## Abstract
 
-Support both unvote and vote actions within a single transaction.
+Support both unvote and vote actions within a single vote transaction.
 
 ## Motivation
 
@@ -46,6 +46,6 @@ Handling vote transaction with asset that contains only a single action (vote or
 
 ## Reference Implementation
 
-It's already implemented, merged, and deployed to devnet. [First multivote transaction] was forged at height 5,640,858 on devnet.
+It's already implemented, merged, published, and [forged on devnet] since height 5,640,858.
 
-[first multivote transaction]: https://dexplorer.ark.io/transactions/004ecc270fbb900c89df36212f85e8f99fa736ad51e2ab06d8307e9af7b89f54
+[forged at devnet]: https://dexplorer.ark.io/transactions/004ecc270fbb900c89df36212f85e8f99fa736ad51e2ab06d8307e9af7b89f54

--- a/AIPS/aip-37.md
+++ b/AIPS/aip-37.md
@@ -1,0 +1,51 @@
+```
+  AIP: 37
+  Title: Multivote Transaction
+  Authors: Dmitry Tyshchenko <dmitry@ark.io>
+  Status: Draft
+  Discussions-To: https://github.com/arkecosystem/AIPS/issues
+  Type: Standards Track
+  Category: Core
+  Created: 2021-07-20
+  Last Update: 2021-07-20
+```
+
+## Abstract
+
+Support both unvote and vote actions within a single transaction.
+
+## Motivation
+
+Currently to change wallet's delegate two separate transactions are necessary:
+
+1. Remove current delegate (e.g. vote `-027716e659220085e41389efc7cf6a05f7f7c659cf3db9126caabce6cda9156582`).
+2. Set new delegate (e.g vote `+03d3c6889608074b44155ad2e6577c3368e27e6e129c457418eb3e5ed029544e8d`).
+
+Combining both actions into a single transaction would slightly reduce core resource consumption and significantly reduce fees that are charged.
+
+## Specification
+
+Fortunately existing vote transaction asset format already supports combining unvote and vote together:
+
+```json
+{
+  "asset": {
+    "votes": [
+      "-027716e659220085e41389efc7cf6a05f7f7c659cf3db9126caabce6cda9156582",
+      "+03d3c6889608074b44155ad2e6577c3368e27e6e129c457418eb3e5ed029544e8d"
+    ]
+  }
+}
+```
+
+No changes to various platform-specific SDK are required.
+
+## Backwards Compatibility
+
+Handling vote transaction with asset that contains only a single action (vote or unvote) remains unchanged.
+
+## Reference Implementation
+
+It's already implemented, merged, and deployed to devnet. [First multivote transaction] was forged at height 5,640,858 on devnet.
+
+[first multivote transaction]: https://dexplorer.ark.io/transactions/004ecc270fbb900c89df36212f85e8f99fa736ad51e2ab06d8307e9af7b89f54


### PR DESCRIPTION
## Summary

Combine both unvote and vote actions into a single transaction.

[Rendered]. Status is _Draft_ although it is already implemented on devnet.

## Checklist

- [x] Documentation
- [x] Ready to be merged

[rendered]: https://github.com/rainydio/AIPs/blob/aip37/AIPS/aip-37.md